### PR TITLE
Adjusted mysql.d to work on Windows

### DIFF
--- a/mysql.d
+++ b/mysql.d
@@ -1,5 +1,10 @@
 module arsd.mysql;
-pragma(lib, "mysqlclient");
+version(Windows) {
+	pragma(lib, "libmysql");
+}
+else {
+	pragma(lib, "mysqlclient");
+}
 
 public import arsd.database;
 
@@ -8,6 +13,18 @@ import std.exception;
 import std.string;
 import std.conv;
 import std.typecons;
+import core.stdc.config;
+
+version(Windows) {
+	extern(Windows) {
+		mixin(mySqlDecl);
+	}
+}
+else {
+	extern(C) {
+		mixin(mySqlDecl);
+	}
+}
 
 class MySqlResult : ResultSet {
 	private int[string] mapping;
@@ -564,7 +581,7 @@ struct ResultByDataObject {
 	MySql mysql;
 }
 
-extern(C) {
+enum mySqlDecl = q{
 	typedef void MYSQL;
 	typedef void MYSQL_RES;
 	typedef const(ubyte)* cstring;
@@ -600,7 +617,7 @@ extern(C) {
 	uint mysql_errno(MYSQL*);
 	cstring mysql_error(MYSQL*);
 
-	MYSQL* mysql_real_connect(MYSQL*, cstring, cstring, cstring, cstring, uint, cstring, ulong);
+	MYSQL* mysql_real_connect(MYSQL*, cstring, cstring, cstring, cstring, uint, cstring, c_ulong);
 
 	int mysql_query(MYSQL*, cstring);
 
@@ -625,7 +642,7 @@ extern(C) {
 
 	void mysql_free_result(MYSQL_RES*);
 
-}
+};
 
 import std.string;
 cstring toCstring(string c) {


### PR DESCRIPTION
Sorry for sticking another pull request on ya ;)

Details about these changes:
- On windows, the dynamic version of mysql ("libmysql.lib", which then automatically loads "libmysql.dll" at runtime) should be used instead of the static version ("mysqlclient.lib"). This is because of the OMF vs COFF issues wih OPTLINK. An OPTLINK-compatible version of a dynamic lib can easily be made (with the freely available implib or coffimplib), but static libs are much harder to use with OPTLINK unless they were built with DMC (and maybe Borland), and MySQL doesn't seem to have an easy way to rebuild the lib on anything but MS and GNU compilers.
- The MySQL libs on Windows use the Windows calling convention instead of the C calling convention. Using string mixins (ie, mySqlDecl) was the only way I could figure to have the same bindings be extern(C) on Posix and extern(Windows) on Windows. The code should still be pretty clear.
- The code to mix in mySqlDecl apperently needs to be at the top to avoid some forward reference problems that apperently still exist in DMD :(
- The last param of mysql_real_connect needed to be "core.stdc.config.c_ulong" instead of "ulong" because on windows (and 32-bit linux), a C long is 32-bit. Leaving it as a ulong caused Access Violation crashes on Windows that drove me absolutely batty until I figured out what was going on.

FWIW, I've tested this patch on both Win32 and 32-bit Ubuntu.
