### PR TITLE
Fixed MYSQL_FIELD for MySQL client >= v5.1

### DIFF
--- a/mysql.d
+++ b/mysql.d
@@ -1,3 +1,5 @@
+/// NOTE: If you're using MySQL client library v5.1 or greater,
+///       you must pass this to dmd: -version=MySQL_51
 module arsd.mysql;
 version(Windows) {
 	pragma(lib, "libmysql");
@@ -597,6 +599,10 @@ extern(System) {
 		  uint charsetnr;     /* Character set */
 		  uint type; /* Type of field. See mysql_com.h for types */
 		  // type is actually an enum btw
+		  
+		version(MySQL_51) {
+			void* extension;
+		}
 	}
 
 	typedef cstring* MYSQL_ROW;


### PR DESCRIPTION
First of all, this pull request says it contains 3 commits, but the only one that's relevent is the last one (named "Fixed MYSQL_FIELD for MySQL client >= v5.1". I don't know what the hell is up with the other two. They don't actually have any changes that weren't already in your repo. (I have to admit I'm turning out to be more of a mercurial guy, and git keeps confusing me...)

In newer versions of MySQL's client library (apparently version 5.1 and onward), an extra "reserved/expansion" field was added to the MYSQL_FIELD  struct. Without that, using any result sets that have more than one field results in weirdness and crashes. So I've adapted DDBI's approach and put the extra field in a version(MySQL_51) block. DDBI's version of the file: http://www.dsource.org/projects/ddbi/browser/trunk/dbi/mysql/c/mysql.d#L676
