### PR TITLE
small fix of types

### DIFF
--- a/postgres.d
+++ b/postgres.d
@@ -167,8 +167,8 @@ string copyCString(const char* c, int actualLength = -1) {
 }
 
 extern(C) {
-	struct PGconn;
-	struct PGresult;
+	struct PGconn {};
+	struct PGresult {};
 
 	void PQfinish(PGconn*);
 	PGconn* PQconnectdb(const char*);


### PR DESCRIPTION
fix postgres.d(44): Error: cannot implicitly convert expression (PQescapeString(buffer,cast(const(char_))cast(immutable(char)_)sqlData,sqlData.length)) of type ulong to int
