### PR TITLE
WndProc nothrow, Thread.sleep changed to use duration

### DIFF
--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -441,13 +441,17 @@ version(Windows) {
 	alias HWND NativeWindowHandle;
 
 	extern(Windows)
-	int WndProc(HWND hWnd, UINT iMessage, WPARAM wParam, LPARAM lParam) {
-		if(hWnd in windowObjects) {
-			auto window = windowObjects[hWnd];
-			return window.windowProcedure(hWnd, iMessage, wParam, lParam);
-		} else {
-			return DefWindowProc(hWnd, iMessage, wParam, lParam);
-		}
+	int WndProc(HWND hWnd, UINT iMessage, WPARAM wParam, LPARAM lParam) nothrow {
+	    try {
+            if(hWnd in windowObjects) {
+                auto window = windowObjects[hWnd];
+                return window.windowProcedure(hWnd, iMessage, wParam, lParam);
+            } else {
+                return DefWindowProc(hWnd, iMessage, wParam, lParam);
+            }
+	    } catch (Exception e) {
+            assert(false, "Exception caught in WndProc");
+	    }
 	}
 
 	mixin template NativeScreenPainterImplementation() {
@@ -772,7 +776,7 @@ version(Windows) {
 
 					if(!done && handlePulse !is null)
 						handlePulse();
-					Thread.sleep(pulseTimeout * 10000);
+					Thread.sleep(dur!"msecs"(pulseTimeout));
 				}
 			} else {
 				while((ret = GetMessage(&message, hwnd, 0, 0)) != 0) {


### PR DESCRIPTION
This commit makes simpledisplay compile under windows. Nothrow was recently added to phobos windows headers, so WndProc must be nothrow. Added a try-catch with asserts(false) on an exception . You probably want to do something better than this, but this at least compiles. 

Thread.sleep(long period) is deprecated, changed it to use dur!"msecs" instead.
