### PR TITLE
Fix compile error with git HEAD.

### DIFF
--- a/terminal.d
+++ b/terminal.d
@@ -1339,7 +1339,7 @@ struct RealTimeConsoleInput {
 
 		import std.utf;
 		size_t throwAway; // it insists on the index but we don't care
-		return decode(buffer, throwAway);
+		return decode(buffer[], throwAway);
 	}
 
 	InputEvent checkWindowSizeChanged() {


### PR DESCRIPTION
Apparently, phobos git HEAD rejects static buffers in `decode()` now. This patch fixes that problem.

There's also a whole bunch of new deprecation messages from `std.datetime`, but I haven't looked into them yet.
