### PR TITLE
Add missing HTML enttires back.

### DIFF
--- a/dom.d
+++ b/dom.d
@@ -1732,7 +1732,7 @@ class Element {
 	}
 
 	///.
-	Element replaceChild(Element find, Element replace) 
+	Element replaceChild(Element find, Element replace)
 		in {
 			assert(find !is null);
 			assert(replace !is null);
@@ -2019,7 +2019,7 @@ class Element {
 	// I moved these from Form because they are generally useful.
 	// Ideally, I'd put them in arsd.html and use UFCS, but that doesn't work with the opDispatch here.
 	/// Tags: HTML, HTML5
-	// FIXME: add overloads for other label types... 
+	// FIXME: add overloads for other label types...
 	Element addField(string label, string name, string type = "text", FormFieldOptions fieldOptions = FormFieldOptions.none) {
 		auto fs = this;
 		auto i = fs.addChild("label");
@@ -2295,56 +2295,11 @@ dchar parseEntity(in dchar[] entity) {
 		case "trade": return '\u2122';
 
 		case "hellip": return '\u2026';
+		case "ndash": return '\u2013';
 		case "mdash": return '\u2014';
+		case "lsquo": return '\u2018';
+		case "rsquo": return '\u2019';
 
-		/*
-		case "cent":
-		case "pound":
-		case "sect":
-		case "deg":
-		case "micro"
-		*/
-		/*
-		case "egrave":
-			return '\u0038';
-		case "Egrave":
-			return '\u00c8';
-		case "times":
-			return '\u00d7';
-		case "hellip":
-			return '\u2026';
-		case "laquo":
-			return '\u00ab';
-		case "raquo":
-			return '\u00bb';
-		case "lsquo":
-			return '\u2018';
-		case "rsquo":
-			return '\u2019';
-		case "ldquo":
-			return '\u201c';
-		case "rdquo":
-			return '\u201d';
-		case "reg":
-			return '\u00ae';
-		case "trade":
-			return '\u2122';
-		case "nbsp":
-			return '\u00a0';
-		case "copy":
-			return '\u00a9';
-		case "eacute":
-			return '\u00e9';
-		case "mdash": return '\u2014';
-		case "ndash":
-			return '\u2013';
-		case "Omicron":
-			return '\u039f';
-		case "omicron":
-			return '\u03bf';
-		case "middot":
-			return '\u00b7';
-		*/
 		// and handling numeric entities
 		default:
 			if(entity[1] == '#') {
@@ -2679,7 +2634,7 @@ class TextNode : Element {
 
 	///.
 	string contents;
-	// alias contents content; // I just mistype this a lot, 
+	// alias contents content; // I just mistype this a lot,
 }
 
 /**
@@ -3443,7 +3398,7 @@ class Document : FileResource {
 	/// Concatenates any consecutive text nodes
 	/*
 	void normalize() {
-		
+
 	}
 	*/
 
@@ -3475,7 +3430,7 @@ class Document : FileResource {
 	/// Return true if you want the node appended to the document.
 	bool delegate(string) parseSawPhpCode;
 
-	/// if it sees a <?xxx> that is not php or asp   
+	/// if it sees a <?xxx> that is not php or asp
 	/// it calls this function with the contents.
 	/// <?SOMETHING foo> calls parseSawQuestionInstruction("?SOMETHING foo")
 	/// Unlike the php/asp ones, this ends on the first > it sees, without requiring ?>.
@@ -4460,7 +4415,7 @@ class Document : FileResource {
 			return null;
 		return e.content;
 	}
-	
+
 	/// Sets a meta tag in the document header. It is kinda hacky to work easily for both Facebook open graph and traditional html meta tags/
 	void setMeta(string name, string value) {
 		string thing = name.indexOf(":") == -1 ? "name" : "property";
@@ -4479,7 +4434,7 @@ class Document : FileResource {
 	}
 
 	///.
-	Form createForm() 
+	Form createForm()
 		out(ret) {
 			assert(ret !is null);
 		}
@@ -4491,7 +4446,7 @@ class Document : FileResource {
 	Element createElement(string name) {
 		if(loose)
 			name = name.toLower();
-	
+
 		auto e = Element.make(name);
 		e.parentDocument = this;
 
@@ -4700,7 +4655,7 @@ int intFromHex(string hex) {
 				}
 			return tid;
 		}
-	
+
 	///.
 	string[] lexSelector(string selector) {
 
@@ -4997,7 +4952,7 @@ int intFromHex(string hex) {
 				/*
 					Like with the < operator, this is best used to find some parent of a particular known element.
 
-					Say you have an anchor inside a 
+					Say you have an anchor inside a
 				*/
 		}
 
@@ -5764,7 +5719,7 @@ private T[] insertAfter(T)(T[] arr, int position, T[] what) {
 	int a = 0;
 	foreach(i; arr[0..position+1])
 		ret[a++] = i;
-	
+
 	foreach(i; what)
 		ret[a++] = i;
 


### PR DESCRIPTION
I added some missing HTML entities back, after I noticed that parsing &ndash; was giving me '?' characters. I'm using this for the new dlang.org stuff.
