### PR TITLE
Range API needs size_t for .length.

### DIFF
--- a/database.d
+++ b/database.d
@@ -147,7 +147,7 @@ interface ResultSet {
 	bool empty() @property;
 	Row front() @property;
 	void popFront() ;
-	int length() @property;
+	size_t length() @property;
 
 	/* deprecated */ final ResultSet byAssoc() { return this; }
 }

--- a/mssql.d
+++ b/mssql.d
@@ -111,7 +111,7 @@ class MsSqlResult : ResultSet {
 			fetchNext;
 	}
 
-	int length()
+	override size_t length()
 	{
 		return 1; //FIX ME
 	}

--- a/mysql.d
+++ b/mysql.d
@@ -72,7 +72,7 @@ class MySqlResult : ResultSet {
 	}
 
 
-	override int length() {
+	override size_t length() {
 		if(result is null)
 			return 0;
 		return cast(int) mysql_num_rows(result);

--- a/postgres.d
+++ b/postgres.d
@@ -126,7 +126,7 @@ class PostgresResult : ResultSet {
 			fetchNext();
 	}
 
-	int length() {
+	override size_t length() {
 		return numRows;
 	}
 

--- a/sqlite.d
+++ b/sqlite.d
@@ -227,8 +227,8 @@ class SqliteResult :  ResultSet {
 		position++;
 	}
 
-	int length() {
-		return cast(int) rows.length;
+	override size_t length() {
+		return rows.length;
 	}
 
 	this(Variant[][] rows, char[][] columnNames) {


### PR DESCRIPTION
Ran into this recently. Phobos is now complaining:
````
/usr/src/d/phobos/std/range/primitives.d(1411): Note: length must have type size_t on all systems, please update your code by December 2017.
````
whenever I use `ResultSet` as a range.

The fix is trivial.

WARNING: I only tested `sqlite.d` for this PR, because that's what I'm currently using. (Thanks, BTW! It's an awesome module, sweet and simple. Just what I need.) But I figured the fix is simple so it shouldn't break anything, so I went ahead and changed it for everything that implements `arsd.Database.ResultSet`. Hope that's OK. If not, I'll be happy to shrink the diff to just `sqlite.d`.