### PR TITLE
[sqlite.d] Fix 64-bit int binding/selecting troubles

### DIFF
--- a/sqlite.d
+++ b/sqlite.d
@@ -325,7 +325,7 @@ struct Statement {
 				Variant v;
 				final switch(sqlite3_column_type(s, a)){
 					case SQLITE_INTEGER:
-						v = sqlite3_column_int(s, a);
+						v = sqlite3_column_int64(s, a);
 					break;
 					case SQLITE_FLOAT:
 						v = sqlite3_column_double(s, a);
@@ -730,6 +730,7 @@ void *sqlite3_column_blob(sqlite3_stmt*, int iCol);
 int sqlite3_column_bytes(sqlite3_stmt*, int iCol);
 double sqlite3_column_double(sqlite3_stmt*, int iCol);
 int sqlite3_column_int(sqlite3_stmt*, int iCol);
+long sqlite3_column_int64(sqlite3_stmt*, int iCol);
 char *sqlite3_column_text(sqlite3_stmt*, int iCol);
 int sqlite3_column_type(sqlite3_stmt*, int iCol);
 char *sqlite3_column_name(sqlite3_stmt*, int N);

--- a/sqlite.d
+++ b/sqlite.d
@@ -502,6 +502,11 @@ template extract(A, T, R...){
 			throw new DatabaseException("bind " ~ db.error());
 	}
 	
+	void bind(int col, long value){
+		if(sqlite3_bind_int64(s, col, value) != SQLITE_OK)
+			throw new DatabaseException("bind " ~ db.error());
+	}
+	
 	void bind(int col, const byte[] value){
 		if(value is null) {
 			if(sqlite3_bind_null(s, col) != SQLITE_OK)
@@ -513,6 +518,8 @@ template extract(A, T, R...){
 	}
 
 	void bind(int col, Variant v) {
+		if(v.peek!long)
+			bind(col, v.get!long);
 		if(v.peek!int)
 			bind(col, v.get!int);
 		if(v.peek!string)
@@ -714,6 +721,7 @@ int sqlite3_bind_blob(sqlite3_stmt*, int, void*, int n, void*);
 //int sqlite3_bind_blob(sqlite3_stmt*, int, void*, int n, void(*)(void*));
 int sqlite3_bind_double(sqlite3_stmt*, int, double);
 int sqlite3_bind_int(sqlite3_stmt*, int, int);
+int sqlite3_bind_int64(sqlite3_stmt*, int, long);
 int sqlite3_bind_null(sqlite3_stmt*, int);
 int sqlite3_bind_text(sqlite3_stmt*, int, const(char)*, int n, void*);
 //int sqlite3_bind_text(sqlite3_stmt*, int, char*, int n, void(*)(void*));


### PR DESCRIPTION
Basically two main changes:

1. Add a 64-bit overload for `bind()` so that 64-bit values are properly bound by SQLite;

2. When returning a result set, extract `SQLITE_INTEGER` as 64-bit instead of 32-bit, so that 64-bit values are converted correctly. For 32-bit fields, the 64-bit return should just convert back to 32-bit losslessly. Not 100% sure if this will cause code breakage; does `Variant` allow casting a 64-bit boxed value to 32-bit implicitly?