### PR TITLE
Fix nanovega compilation warnings

### DIFF
--- a/nanovega.d
+++ b/nanovega.d
@@ -13205,7 +13205,7 @@ bool glnvg__renderCreate (void* uptr) nothrow @trusted @nogc {
     }
   };
 
-  enum fillFragShader = q{
+  enum fillFragShader = `
     uniform vec4 frag[UNIFORM_ARRAY_SIZE];
     uniform sampler2D tex;
     uniform sampler2D clipTex;
@@ -13311,7 +13311,7 @@ bool glnvg__renderCreate (void* uptr) nothrow @trusted @nogc {
       }
       gl_FragColor = color;
     }
-  };
+  `;
 
   enum clipVertShaderFill = q{
     uniform vec2 viewSize;


### PR DESCRIPTION
#include and #define made dmd and ldc very unhappy.

Fixes
```
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13215,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13216,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13217,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13218,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13219,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13220,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13221,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13222,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13223,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13224,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13225,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13226,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13227,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13228,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13229,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13230,12): Warning: C preprocessor directive #define is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13245,11): Warning: C preprocessor directive #ifdef is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13250,11): Warning: C preprocessor directive #endif is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13261,13): Warning: C preprocessor directive #ifdef is not supported
/home/webfreak/.dub/packages/arsd-official-2.1.2/arsd-official/nanovega.d(13266,13): Warning: C preprocessor directive #endif is not supported
```