### PR TITLE
Update jpeg.d

### DIFF
--- a/jpeg.d
+++ b/jpeg.d
@@ -3149,8 +3149,9 @@ public ubyte[] decompress_jpeg_image_from_file(bool useMalloc=false) (const(char
 
   if (filename.length == 0) throw new Exception("cannot open unnamed file");
   if (filename.length < 2048) {
-    import core.stdc.stdlib : alloca;
-    auto tfn = (cast(char*)alloca(filename.length+1))[0..filename.length+1];
+	char[2049] buffer;
+    //import core.stdc.stdlib : alloca;
+    auto tfn = buffer[0 .. filename.length + 1]; // (cast(char*)alloca(filename.length+1))[0..filename.length+1];
     tfn[0..filename.length] = filename[];
     tfn[filename.length] = 0;
     m_pFile = fopen(tfn.ptr, "rb");
@@ -3340,8 +3341,9 @@ public MemoryImage readJpeg (const(char)[] filename) {
 
   if (filename.length == 0) throw new Exception("cannot open unnamed file");
   if (filename.length < 2048) {
-    import core.stdc.stdlib : alloca;
-    auto tfn = (cast(char*)alloca(filename.length+1))[0..filename.length+1];
+	char[2049] buffer;
+    //import core.stdc.stdlib : alloca;
+    auto tfn = buffer[0 .. filename.length + 1]; // (cast(char*)alloca(filename.length+1))[0..filename.length+1];
     tfn[0..filename.length] = filename[];
     tfn[filename.length] = 0;
     m_pFile = fopen(tfn.ptr, "rb");


### PR DESCRIPTION
I did what you had already done before to all instances of core.stdc.stdlib.alloca() calls to solve the error with -m64.