### PR TITLE
Fixing the Rectangle.contains() function

### DIFF
--- a/color.d
+++ b/color.d
@@ -1512,7 +1512,7 @@ struct Rectangle {
 
 	/// ditto
 	bool contains(in Point p) {
-		return (p.x >= left && p.y < right && p.y >= top && p.y < bottom);
+		return (left <= p.x && p.x < right && top <= p.y && p.y < bottom);
 	}
 
 	/// Returns true of the two rectangles at any point overlap


### PR DESCRIPTION
There was a typo, I corrected it and I rewrote the line in a way that I think is more elegant since it follows the same way of writing in math where you just write a <= x < b.