### PR TITLE
Fixing a little logic bug

### DIFF
--- a/color.d
+++ b/color.d
@@ -1477,7 +1477,7 @@ struct Rectangle {
 
 	///
 	this(in Point upperLeft, in Size size) {
-		this(upperLeft.x, upperLeft.y, upperLeft.x + size.width, upperLeft.y + size.height);
+		this(upperLeft.x, upperLeft.y, upperLeft.x + size.width - 1, upperLeft.y + size.height - 1);
 	}
 
 	///
@@ -1507,12 +1507,12 @@ struct Rectangle {
 
 	///
 	@property int width() {
-		return right - left;
+		return right - left + 1;
 	}
 
 	///
 	@property int height() {
-		return bottom - top;
+		return bottom - top + 1;
 	}
 
 	/// Returns true if this rectangle entirely contains the other


### PR DESCRIPTION
I needed to subtract and later add a 1 because otherwise it would return wrong values. Suppose you have a rectangle starting at (0, 0) with size (15, 15), then .bottom and .right must be 14 rather than 15 cause its size is 15 pixels, starting at 0 it goes all the way to 14 and not to 15(the 0 also counts), hence the -1. And therefore its width will be returned 14 - 0 which is 14 and it should be 15 because the 0 also counts, hence the +1.