### PR TITLE
Support big images

### DIFF
--- a/color.d
+++ b/color.d
@@ -923,7 +923,7 @@ class IndexedImage : MemoryImage {
 
 	override Color getPixel(int x, int y) const pure nothrow @trusted @nogc {
 		if (x >= 0 && y >= 0 && x < _width && y < _height) {
-			uint pos = y*_width+x;
+			size_t pos = cast(size_t)y*_width+x;
 			if (pos >= data.length) return Color(0, 0, 0, 0);
 			ubyte b = data.ptr[pos];
 			if (b >= palette.length) return Color(0, 0, 0, 0);
@@ -935,7 +935,7 @@ class IndexedImage : MemoryImage {
 
 	override void setPixel(int x, int y, in Color clr) nothrow @trusted {
 		if (x >= 0 && y >= 0 && x < _width && y < _height) {
-			uint pos = y*_width+x;
+			size_t pos = cast(size_t)y*_width+x;
 			if (pos >= data.length) return;
 			ubyte pidx = findNearestColor(palette, clr);
 			if (palette.length < 255 &&
@@ -954,7 +954,11 @@ class IndexedImage : MemoryImage {
 	this(int w, int h) pure nothrow @safe {
 		_width = w;
 		_height = h;
-		data = new ubyte[w*h];
+
+        // ensure that the computed size does not exceed basic address space limits
+        assert(cast(ulong)w * h  <= size_t.max);
+        // upcast to avoid overflow for images larger than 536 Mpix
+		data = new ubyte[cast(size_t)w*h];
 	}
 
 	/*
@@ -1061,7 +1065,7 @@ class TrueColorImage : MemoryImage {
 
 	override Color getPixel(int x, int y) const pure nothrow @trusted @nogc {
 		if (x >= 0 && y >= 0 && x < _width && y < _height) {
-			uint pos = y*_width+x;
+			size_t pos = cast(size_t)y*_width+x;
 			return imageData.colors.ptr[pos];
 		} else {
 			return Color(0, 0, 0, 0);
@@ -1070,7 +1074,7 @@ class TrueColorImage : MemoryImage {
 
 	override void setPixel(int x, int y, in Color clr) nothrow @trusted {
 		if (x >= 0 && y >= 0 && x < _width && y < _height) {
-			uint pos = y*_width+x;
+			size_t pos = cast(size_t)y*_width+x;
 			if (pos < imageData.bytes.length/4) imageData.colors.ptr[pos] = clr;
 		}
 	}
@@ -1079,14 +1083,19 @@ class TrueColorImage : MemoryImage {
 	this(int w, int h) pure nothrow @safe {
 		_width = w;
 		_height = h;
-		imageData.bytes = new ubyte[w*h*4];
+
+		// ensure that the computed size does not exceed basic address space limits
+        assert(cast(ulong)w * h * 4 <= size_t.max);
+        // upcast to avoid overflow for images larger than 536 Mpix
+		imageData.bytes = new ubyte[cast(size_t)w * h * 4];
 	}
 
 	/// Creates with existing data. The data pointer is stored here.
 	this(int w, int h, ubyte[] data) pure nothrow @safe {
 		_width = w;
 		_height = h;
-		assert(data.length == w * h * 4);
+		assert(cast(ulong)w * h * 4 <= size_t.max);
+		assert(data.length == cast(size_t)w * h * 4);
 		imageData.bytes = data;
 	}
 

--- a/nanovega.d
+++ b/nanovega.d
@@ -12198,6 +12198,7 @@ version(bindbc){
     alias GLchar = char;
     alias GLsizei = int;
     alias GLfloat = float;
+    alias GLintptr = size_t;
     alias GLsizeiptr = ptrdiff_t;
 
     enum uint GL_STENCIL_BUFFER_BIT = 0x00000400;
@@ -12312,6 +12313,8 @@ version(bindbc){
     __gshared glbfn_glDeleteVertexArrays glDeleteVertexArrays_NVGLZ; alias glDeleteVertexArrays = glDeleteVertexArrays_NVGLZ;
     alias glbfn_glGenerateMipmap = void function(GLenum);
     __gshared glbfn_glGenerateMipmap glGenerateMipmap_NVGLZ; alias glGenerateMipmap = glGenerateMipmap_NVGLZ;
+    alias glbfn_glBufferSubData = void function(GLenum, GLintptr, GLsizeiptr, const(GLvoid)*);
+    __gshared glbfn_glBufferSubData glBufferSubData_NVGLZ; alias glBufferSubData = glBufferSubData_NVGLZ;
 
     alias glbfn_glStencilMask = void function(GLuint);
     __gshared glbfn_glStencilMask glStencilMask_NVGLZ; alias glStencilMask = glStencilMask_NVGLZ;
@@ -12413,6 +12416,8 @@ version(bindbc){
       if (glDeleteVertexArrays_NVGLZ is null) assert(0, `OpenGL function 'glDeleteVertexArrays' not found!`);
       glGenerateMipmap_NVGLZ = cast(glbfn_glGenerateMipmap)glbindGetProcAddress(`glGenerateMipmap`);
       if (glGenerateMipmap_NVGLZ is null) assert(0, `OpenGL function 'glGenerateMipmap' not found!`);
+      glBufferSubData_NVGLZ = cast(glbfn_glBufferSubData)glbindGetProcAddress(`glBufferSubData`);
+      if (glBufferSubData_NVGLZ is null) assert(0, `OpenGL function 'glBufferSubData' not found!`);
 
       glStencilMask_NVGLZ = cast(glbfn_glStencilMask)glbindGetProcAddress(`glStencilMask`);
       if (glStencilMask_NVGLZ is null) assert(0, `OpenGL function 'glStencilMask' not found!`);


### PR DESCRIPTION
I've run into some integer overflow issues with color.d and png.d when trying to work with images that have slightly bigger dimensions than normal, this PR fixes those issues.
- setPixel doesn't produce bogus array indices for sane input anymore.
- saving and loading big images works now (on 64 bit platforms).
In a basic test using a 30000x20000 RGBA image, the image could be saved correctly and decoded correctly both in it's original encoding and in reencoded (by external tool) form. Before the fix the output file was terminated abruptly and broken.