### PR TITLE
Recognize TERM=rxvt-unicode-256color.

### DIFF
--- a/terminal.d
+++ b/terminal.d
@@ -308,7 +308,7 @@ vs|xterm|xterm-color|xterm-256color|vs100|xterm terminal emulator (X Window Syst
 
 
 #rxvt, added by me
-rxvt|rxvt-unicode:\
+rxvt|rxvt-unicode|rxvt-unicode-256color:\
 	:am:bs:mi@:km:co#80:li#55:\
 	:im@:ei@:\
 	:ct=\E[3k:ue=\E[m:\


### PR DESCRIPTION
See issue #209. As it turns out, the problem wasn't 256 color support itself, but the fact that on my Debian box `TERM` is set to `rxvt-unicode-256color`, but `terminal.d` doesn't recognize this particular string.  Not 100% sure this is the right fix, but it did at least display 16-color mode correctly. I'll try a small 256-color test program next.