### PR TITLE
Setting up the .clear() method better

### DIFF
--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -6436,10 +6436,10 @@ struct ScreenPainter {
 	}
 
 	///
-	void clear() {
+	void clear(Color color = Color.black()) {
 		if(impl is null) return;
-		fillColor = Color(255, 255, 255);
-		outlineColor = Color(255, 255, 255);
+		fillColor = color;
+		outlineColor = color;
 		drawRectangle(Point(0, 0), window.width, window.height);
 	}
 


### PR DESCRIPTION
I've made the .clear() method more practical by giving the user the ability to decide which color the screen will be cleared with and setting the default as black since this is what you will probably be using.