### PR TITLE
Improving the pressKey() method

### DIFF
--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -5655,7 +5655,9 @@ version (X11) {
 
 		///
 		void pressKey(Key key, bool pressed, int delay = 0) {
-			XTestFakeKeyEvent(XDisplayConnection.get, XKeysymToKeycode(XDisplayConnection.get, key), pressed, delay + pressed ? 0 : 5);
+			auto screen = XDisplayConnection.get();
+			XTestFakeKeyEvent(screen, XKeysymToKeycode(XDisplayConnection.get, key), pressed, delay + pressed ? 0 : 5);
+			XFlush(screen);
 		}
 
 		///


### PR DESCRIPTION
If you want to press a key repeatedly with a time interval then you need to flush the GUI every time you do it. For instance, supposing you want to create a program that keeps pressing F5 to reload a web page every 5 seconds. I tried using the code below and it didn't work until I added the flush function:
    SyntheticInput fake = SyntheticInput(0);
    bool forever = true;
    while (forever)
    {
        fake.pressKey(Key.F5, true);
        fake.pressKey(Key.F5, false);
        Thread.sleep(5.seconds);
    }