### PR TITLE
Fix deprecation warnings for `body`.

### DIFF
--- a/color.d
+++ b/color.d
@@ -1225,7 +1225,7 @@ alias extern(C) int function(scope const void*, scope const void*) @system Compa
 IndexedImage quantize(in TrueColorImage img, Color[] palette = null, in int maxColors = 256)
 	// this is just because IndexedImage assumes ubyte palette values
 	in { assert(maxColors <= 256); }
-body {
+do {
 	int[Color] uses;
 	foreach(pixel; img.imageData.colors) {
 		if(auto i = pixel in uses) {

--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -2009,7 +2009,7 @@ class SimpleWindow : CapableOfHandlingNativeEvent, CapableOfBeingDrawnUpon {
 	void opacity(double opacity) @property
 	in {
 		assert(opacity >= 0 && opacity <= 1);
-	} body {
+	} do {
 		version (Windows) {
 			impl.setOpacity(cast(ubyte)(255 * opacity));
 		} else version (X11) {
@@ -16705,7 +16705,7 @@ class ExperimentalTextComponent2 {
 		this(Color f, Color b, OperatingSystemFont font, ubyte attr, const(char)[] c)
 			in { assert(font !is null);
 			     assert(!font.isNull); }
-			body
+			do
 		{
 			this.foreground = f;
 			this.background = b;


### PR DESCRIPTION
Trivial fix, just thought I'd help get rid of annoying deprecation messages.