### PR TITLE
database_generation: Don't assign to functions, ... in populateFromDbRow

### DIFF
--- a/database.d
+++ b/database.d
@@ -1468,5 +1468,57 @@ struct varchar(size_t max) {
 	alias asString this;
 }
 
+version (unittest)
+{
+	/// Unittest utility that returns a predefined set of values
+	package (arsd) final class PredefinedResultSet : ResultSet
+	{
+		string[] fields;
+		Row[] rows;
+		size_t current;
 
+		this(string[] fields, Row[] rows)
+		{
+			this.fields = fields;
+			this.rows = rows;
+			foreach (ref row; rows)
+				row.resultSet = this;
+		}
 
+		int getFieldIndex(const string field) const
+		{
+			foreach (const idx, const val; fields)
+				if (val == field)
+					return cast(int) idx;
+
+			assert(false, "No field with name: " ~ field);
+		}
+
+		string[] fieldNames()
+		{
+			return fields;
+		}
+
+		@property bool empty() const
+		{
+			return current == rows.length;
+		}
+
+		Row front() @property
+		{
+			assert(!empty);
+			return rows[current];
+		}
+
+		void popFront()
+		{
+			assert(!empty);
+			current++;
+		}
+
+		size_t length() @property
+		{
+			return rows.length - current;
+		}
+	}
+}

--- a/database_generation.d
+++ b/database_generation.d
@@ -341,11 +341,28 @@ void insert(O)(ref O t, Database db) {
 		foreach(row; db.query("SELECT max(id) FROM " ~ toTableName(O.stringof)))
 			t.id.value = to!int(row[0]);
 	} else {
-		foreach(row; builder.execute(db, "RETURNING id")) // FIXME: postgres-ism
-			t.id.value = to!int(row[0]);
+		static if (__traits(hasMember, O, "id"))
+		{
+			foreach(row; builder.execute(db, "RETURNING id")) // FIXME: postgres-ism
+				t.id.value = to!int(row[0]);
+		}
+		else
+		{
+			builder.execute(db);
+		}
 	}
 }
 
+// Check that insert doesn't require an `id`
+unittest
+{
+	static struct NoPK
+	{
+		int a;
+	}
+
+	alias test = insert!NoPK;
+}
 ///
 class RecordNotFoundException : Exception {
 	this() { super("RecordNotFoundException"); }


### PR DESCRIPTION
Using `tupleof` instead of `__traits(allMembers, ...)` skips over all
nested declarations that are not actual fields.