### PR TITLE
update list of self-closing tags

### DIFF
--- a/dom.d
+++ b/dom.d
@@ -5582,9 +5582,9 @@ struct DomMutationEvent {
 
 private immutable static string[] htmlSelfClosedElements = [
 	// html 4
-	"img", "hr", "input", "br", "col", "link", "meta",
+	"area","base","br","col","hr","img","input","link","meta","param",
 	// html 5
-	"source" ];
+	"embed","source","track","wbr" ];
 
 private immutable static string[] htmlInlineElements = [
 	"span", "strong", "em", "b", "i", "a"


### PR DESCRIPTION
I added the tags:
`area`, `base`, `param`, `embed`, `track`, and `wbr`

Used the list from here
https://developer.mozilla.org/en-US/docs/Glossary/Empty_element