### PR TITLE
make children take DBName into consideration

### DIFF
--- a/database_generation.d
+++ b/database_generation.d
@@ -500,7 +500,7 @@ QueryBuilderHelper!(T[]) children(T, B)(B base) {
 	// return QueryBuilderHelper!(T[])(toTableName(T.stringof)).where!(mixin(keyName ~ " => base.id"));
 
 	// changing mixin cuz of regression in dmd 2.088
-	mixin("return QueryBuilderHelper!(T[])(toTableName(T.stringof)).where!("~keyName ~ " => base.id);");
+	mixin("return QueryBuilderHelper!(T[])(tableNameFor!T()).where!("~keyName ~ " => base.id);");
 }
 
 /++


### PR DESCRIPTION
Use `tableNameFor` which takes into consideration DBName instead of `toTableName`.