### PR TITLE
One to many handle empty str

### DIFF
--- a/database_generation.d
+++ b/database_generation.d
@@ -920,8 +920,9 @@ string toFieldName(T)(string s, bool isPlural = false)
 	}
 	---
 
-	if t2 or t1 are set as null they will be inferred from either
-	the `DBName` attribute or from the name of the Table
+	if t2 or t1 are set as "" the get function will not be generated
+	(the name will not be inferred), if set as null they will be inferred from
+	either the `DBName` attribute or from the name of the Table.
 
 	History:
 		Added November 5, 2022 (dub v10.10)

--- a/database_generation.d
+++ b/database_generation.d
@@ -941,7 +941,7 @@ template one_to_many(alias fk_field, string t2 = null, string t1 = null)
 	immutable string t2_name = toFieldName!T2(t2);
 	immutable string t1_name = toFieldName!T1(t1, true);
 
-	static immutable string one_to_many =
+	static immutable string one = (t2 is "") ? "" :
 		T2.stringof~` get_`~t2_name~`(`~T1.stringof~` row, Database db)
 		{
 			import std.exception;
@@ -955,7 +955,8 @@ template one_to_many(alias fk_field, string t2 = null, string t1 = null)
 			).to_table_rows!`~T2.stringof~`;
 
 			return res.front();
-		}
+		}`;
+	static immutable string many = (t1 is "") ? "" : `
 		TabResultSet!`~T1.stringof~` get_`~t1_name~`(`~T2.stringof~` row, Database db)
 		{
 			import std.exception;
@@ -970,4 +971,5 @@ template one_to_many(alias fk_field, string t2 = null, string t1 = null)
 
 			return res;
 		}`;
+	static immutable string one_to_many = one ~ many;
 }

--- a/database_generation.d
+++ b/database_generation.d
@@ -928,20 +928,18 @@ string toFieldName(T)(string s, bool isPlural = false)
 +/
 template one_to_many(alias fk_field, string t2 = null, string t1 = null)
 {
-	private {
-		alias T1 = __traits(parent, fk_field);
+	alias T1 = __traits(parent, fk_field);
 
-		static assert(
-			isFieldRefInAttributes!(__traits(getAttributes, fk_field)),
-			T1.stringof ~ "." ~ fk_field.stringof ~ " does't have a ForeignKey");
+	static assert(
+		isFieldRefInAttributes!(__traits(getAttributes, fk_field)),
+		T1.stringof ~ "." ~ fk_field.stringof ~ " does't have a ForeignKey");
 
-		alias FieldRef = getRefToField!(fk_field);
-		alias T2 = FieldRef.Table;
-		alias ref_field = FieldRef.field;
+	alias FieldRef = getRefToField!(fk_field);
+	alias T2 = FieldRef.Table;
+	alias ref_field = FieldRef.field;
 
-		immutable string t2_name = toFieldName!T2(t2);
-		immutable string t1_name = toFieldName!T1(t1, true);
-	}
+	immutable string t2_name = toFieldName!T2(t2);
+	immutable string t1_name = toFieldName!T1(t1, true);
 
 	static immutable string one_to_many =
 		T2.stringof~` get_`~t2_name~`(`~T1.stringof~` row, Database db)


### PR DESCRIPTION
Handle when "" is passed to t1 or t2.
Currently if "" gets passed to t1 or t2 it will just result in a compilation error. This pr handles that case by not generating the respective function if t1 or t2 is left empty. Example
```d
struct Role { int id; }

struct User {
    int id;
    @ForeignKey!(Role.id, "") int role_id;
}

mixin(one_to_many(User.role_id, "role", ""));
Database db = ...
User user = ...
Role role = user.get_role(db); / / Works
auto users = role.get_users(db); // Doesn't because t1 is ""
```