### PR TITLE
Add integral field check to find

### DIFF
--- a/database_generation.d
+++ b/database_generation.d
@@ -409,6 +409,9 @@ static auto find(alias T)(Database db, int id) {
 		alias TType = T;
 	}
 
+	static assert(is(FType : int),
+			TType.stringof ~ "." ~ fieldName ~ " should be an Integral field");
+
 	string q = "SELECT * FROM " ~ tableNameFor!TType() ~ " WHERE " ~ fieldName ~ " = ?";
 	foreach(record; db.query(q, id)) {
 		TType t;


### PR DESCRIPTION
Basically makes clearer the fact that `find` only works with Integral fields, and makes debugging easier.

P.S. I forgot to add this in the previous pr. Sorry.