### PR TITLE
Fix cgi.d unittest compile error:

### DIFF
--- a/cgi.d
+++ b/cgi.d
@@ -555,7 +555,7 @@ unittest {
 unittest {
 	import arsd.cgi;
 
-	void requestHandler(Cgi cgi) {
+	static void requestHandler(Cgi cgi) {
 
 	}
 


### PR DESCRIPTION
To fix this error when compiling with -unittest:

````
arsd/cgi.d(565): Error: constructor `arsd.cgi.CgiTester.this(void function(Cgi) requestHandler)` is not callable using argument types `(void delegate(Cgi cgi) pure nothrow @nogc @safe)`
arsd/cgi.d(565):        cannot pass argument `&requestHandler` of type `void delegate(Cgi cgi) pure nothrow @nogc @safe` to parameter `void function(Cgi) requestHandler`
````