### PR TITLE
bugfix: scrollbar wasn't updating on addtext calls

### DIFF
--- a/minigui.d
+++ b/minigui.d
@@ -12487,6 +12487,7 @@ abstract class EditableTextWidget : EditableTextWidgetParent {
 		version(custom_widgets) {
 			version(use_new_text_system) {
 				textLayout.appendText(txt);
+				tdh.adjustScrollbarSizes();
 				redraw();
 			} else {
 				textLayout.addText(txt);


### PR DESCRIPTION
When you use the addtext method on the TextEdit class, the scrollbar does not recalculate its size properly.  
This is a simple fix. 
 
Preview of the error in action
![Screenshot without bugfix](https://github.com/adamdruppe/arsd/assets/105025804/451efdd9-4c7c-4107-be79-5e5064a2c42e)

Preview of the fix in action
![Screenshot with bugfix](https://github.com/adamdruppe/arsd/assets/105025804/a9e4fbe8-6e0e-4a2c-94d4-968d82b9e243)
