### PR TITLE
Use the alias socklen_t for portability

### DIFF
--- a/cgi.d
+++ b/cgi.d
@@ -8844,11 +8844,7 @@ void runAddonServer(EIS)(string localListenerName, EIS eis) if(is(EIS : EventIoS
 				void newConnection() {
 					// on edge triggering, it is important that we get it all
 					while(true) {
-						version(Android) {
-							auto size = cast(int) addr.sizeof;
-						} else {
-							auto size = cast(uint) addr.sizeof;
-						}
+						auto size = cast(socklen_t) addr.sizeof;
 						auto ns = accept(sock, cast(sockaddr*) &addr, &size);
 						if(ns == -1) {
 							if(errno == EAGAIN || errno == EWOULDBLOCK) {


### PR DESCRIPTION
cgi.d currently manually casts socklen_t to int on android. Currently, the [current commit in druntime] (https://github.com/dlang/dmd/blob/1188adc84ff1777f4a0153a8a5d7729ab5866dce/druntime/src/core/sys/posix/sys/socket.d)  aliases socklen_t as uint, I can't find an exception for android or ARM.

To stay more robust to further changes in the druntime core library, I suggest just using socklen_t directly. I tested this on android 13 (termux) and linux. 