### PR TITLE
add MouseButtonLinear to sdpy

### DIFF
--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -10601,6 +10601,17 @@ enum MouseButton : int {
 	forwardButton = 64, /// often found on the thumb and used for forward in browsers
 }
 
+/// Corresponds to the values found in MouseEvent.buttonLinear, being equal to `core.bitop.bsf(button) + 1`
+enum MouseButtonLinear : ubyte {
+	left = 1, ///
+	right, ///
+	middle, ///
+	wheelUp, ///
+	wheelDown, ///
+	backButton, /// often found on the thumb and used for back in browsers
+	forwardButton, /// often found on the thumb and used for forward in browsers
+}
+
 version(X11) {
 	// FIXME: match ASCII whenever we can. Most of it is already there,
 	// but there's a few exceptions and mismatches with Windows


### PR DESCRIPTION
my use-case:

```d
	struct MouseState
	{
		bool dragging;
		int dragStartX, dragStartY;
		int dragModifierState;
		bool qualifiesClick;
	}
	MouseState[16] mouseButtonStates;
	void handleMouseEvent(MouseEvent e)
	{
		import std.math : abs, round;

		if (e.type == MouseEventType.motion)
		{
			foreach (btn, ref state; mouseButtonStates)
			{
				if (state.qualifiesClick && abs(e.x - state.dragStartX) + abs(e.y - state.dragStartY) > 8)
					state.qualifiesClick = false;
				else if (state.dragging && (btn == MouseButtonLinear.middle
					|| ((state.dragModifierState & ModifierState.alt) != 0
						&& (btn == MouseButtonLinear.left || btn == MouseButtonLinear.right))))
				{
					viewOffsetX += e.dx;
					viewOffsetY += e.dy;
				}
			}
		}
		...
```