### PR TITLE
Add ctor for making Pixmaps from user-provided slice

### DIFF
--- a/pixmappresenter.d
+++ b/pixmappresenter.d
@@ -226,8 +226,16 @@ struct Pixmap {
 
 @safe pure nothrow:
 
+	///
 	this(Size size) {
 		this.size = size;
+	}
+
+	///
+	this(Pixel[] data, int width) @nogc
+	in (data.length % width == 0) {
+		this.data = data;
+		this.width = width;
 	}
 
 	// undocumented: really shouldn’t be used.


### PR DESCRIPTION
Noticed that this ctor was missing.

It’s just a convenience feature but I think it’s useful enough. My original codebase had it. (Currently porting it to use PixmapPresenter.)