### PR TITLE
Remove an allocation when decoding base64

### DIFF
--- a/email.d
+++ b/email.d
@@ -1179,6 +1179,18 @@ immutable(ubyte[]) decodeBase64Mime(string encodedPart) {
 		.array;
 }
 
+unittest {
+	// Mime base64 roundtrip
+	import std.algorithm.comparison;
+	string source = chain(
+		repeat('n', 1200), //long line
+		"\r\n",
+		"äöü\r\n",
+		"ඞ\rn",
+		).byChar.array;
+	assert( source.representation.encodeBase64Mime.decodeBase64Mime.equal(source));
+}
+
 /+
 void main() {
 	import std.file;

--- a/email.d
+++ b/email.d
@@ -1174,9 +1174,7 @@ alias base64decode = Base64.decoder;
 immutable(ubyte[]) decodeBase64Mime(string encodedPart) {
 	return cast(immutable(ubyte[])) encodedPart
 		.byChar // prevent Autodecoding, which will break Base64 decoder. Since its base64, it's guarenteed to be 7bit ascii
-		.filter!((c) => c != '\r')
-		.splitter!((c) => c == '\n')
-		.joiner
+		.filter!((c) => (c != '\r') & (c != '\n'))
 		.base64decode
 		.array;
 }


### PR DESCRIPTION
Untested POC. I'll probably get around to create some tests for this on the weekend.