### PR TITLE
com.d: Fix EXCEPINFO.scode capitalization

### DIFF
--- a/com.d
+++ b/com.d
@@ -971,7 +971,7 @@ mixin template IDispatchImpl() {
 				} catch(Throwable e) {
 					// FIXME: fill in the exception info
 					if(except !is null) {
-						except.sCode = 1;
+						except.scode = 1;
 						import std.utf;
 						except.bstrDescription = SysAllocString(toUTFz!(wchar*)(e.toString()));
 						except.bstrSource = SysAllocString("amazing"w.ptr);


### PR DESCRIPTION
Not sure how close to finished the `ComObjectImpl` and `IDispatchImpl` mixins are, but this at least helps getting rid of a compile error.