### PR TITLE
com.d: Add option for multithreaded COM

### DIFF
--- a/com.d
+++ b/com.d
@@ -196,11 +196,12 @@ shared static ~this() {
 }
 
 ///
-void initializeClassicCom() {
+void initializeClassicCom(bool multiThreaded = false) {
 	if(coInitializeCalled)
 		return;
 
-	ComCheck(CoInitialize(null), "COM initialization failed");
+	ComCheck(CoInitializeEx(null, multiThreaded ? COINIT_MULTITHREADED : COINIT_APARTMENTTHREADED),
+		"COM initialization failed");
 
 	coInitializeCalled++;
 }


### PR DESCRIPTION
When Excel calls back into my application through `IDispatch.Invoke` from an object I passed through `Advise`, it hangs and eventually a pop up shows "Microsoft Excel is waiting for another application to complete an OLE action". Turns out I need to use `COINIT_MULTITHREADED`. This adds an option for it while remaining backwards compatible with the COINIT_APARTMENTTHREADED default.