### PR TITLE
Fix for error at string to char* conversion in `executePreparedStatement` in Postgres.d

### DIFF
--- a/postgres.d
+++ b/postgres.d
@@ -85,16 +85,17 @@ class PostgreSql : Database {
 	*/
 
 	ResultSet executePreparedStatement(T...)(string name, T args) {
-		char*[args.length] argsStrings;
+		const(char)*[args.length] argsStrings;
 
 		foreach(idx, arg; args) {
 			// FIXME: optimize to remove allocations here
+			import std.conv;
 			static if(!is(typeof(arg) == typeof(null)))
 				argsStrings[idx] = toStringz(to!string(arg));
 			// else make it null
 		}
 
-		auto res = PQexecPrepared(conn, toStringz(name), argsStrings.length, argStrings.ptr, 0, null, 0);
+		auto res = PQexecPrepared(conn, toStringz(name), argsStrings.length, argsStrings.ptr, null, null, 0);
 
 		int ress = PQresultStatus(res);
 		if(ress != PGRES_TUPLES_OK


### PR DESCRIPTION

Dependency was throwing error 
`
template instance `arsd.postgres.PostgreSql.executePreparedStatement!(char, char)` error instantiating `
when  use executePreparedStatement

DUB : 1.38.1
PostgreSQL: 16

I got this error in the package 

`
template 'to' is not callable using argument types '!(string)(char)'`
where the usage is ` db.executePreparedStatement("update_tbl_cmd",'3','a');`