### PR TITLE
Document Pixmap Paint module

### DIFF
--- a/pixmappaint.d
+++ b/pixmappaint.d
@@ -2,6 +2,9 @@
 	== pixmappaint ==
 	Copyright Elias Batek (0xEAB) 2024.
 	Distributed under the Boost Software License, Version 1.0.
++/
+/++
+	Pixmap image manipulation
 
 	$(WARNING
 		$(B Early Technology Preview.)


### PR DESCRIPTION
I’m not sure whether leaving it undocumented was on purpose.
Also it left out the “tech preview” warning from the generated documentation.

I’d say, let’s document it :grin: 