### PR TITLE
core.d: Fix wrong `return` annotation on UserProvidedBuffer.slice

### DIFF
--- a/core.d
+++ b/core.d
@@ -3598,7 +3598,7 @@ struct UserProvidedBuffer(T) {
 		}
 	}
 
-	package(arsd) T[] slice() return {
+	package(arsd) T[] slice() {
 		return buffer[0 .. actualLength];
 	}
 }


### PR DESCRIPTION
There's a compile error when using `-preview=dip1000`:

```D
	static SocketAddress[] localhost(ushort port, return UserProvidedBuffer!SocketAddress buffer = null) {
		buffer.append(ip6("::1", port));
		buffer.append(ip4("127.0.0.1", port));
		return buffer.slice;
	}
```

```
C:\Users\Dennis\AppData\Local\dub\packages\arsd-official\11.4.2\arsd-official\core.d(3066,10): Error: returning `buffer.slice()` escapes a reference to parameter `buffer`
C:\Users\Dennis\AppData\Local\dub\packages\arsd-official\11.4.2\arsd-official\core.d(3181,10): Error: returning `buffer.slice()` escapes a reference to parameter `buffer`
```

The `UserProvidedBuffer.slice` method is annotated `return (ref)` but it should be `return scope`, or since it's a template, just inferred.