### PR TITLE
Implement "corner style" property for sdpy windows on Windows 11+

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -28,12 +28,12 @@
 			"configurations": [
 				{
 					"name": "normal",
-					"libs-windows": ["gdi32", "ole32"]
+					"libs-windows": ["dwmapi", "gdi32", "ole32"]
 				},
 				{
 					"name": "without-opengl",
 					"versions": ["without_opengl"],
-					"libs-windows": ["gdi32", "ole32"]
+					"libs-windows": ["dwmapi", "gdi32", "ole32"]
 				},
 				{
 					"name": "cocoa",

--- a/pixmappresenter.d
+++ b/pixmappresenter.d
@@ -408,8 +408,26 @@ struct PresenterConfig {
 
 	///
 	static struct Window {
+		///
 		string title = "ARSD Pixmap Presenter";
+
+		///
 		Size size;
+
+		/++
+			Window corner style
+
+			$(NOTE
+				At the time of writing, this is only implemented on Windows.
+				It has no effect elsewhere for now but does no harm either.
+
+				Windows: Requires Windows 11 or later.
+			)
+
+			History:
+				Added September 10, 2024.
+		 +/
+		CornerStyle corners = CornerStyle.rectangular;
 	}
 }
 
@@ -911,6 +929,7 @@ final class PixmapPresenter {
 			);
 
 			window.windowResized = &this.windowResized;
+			window.cornerStyle = config.window.corners;
 
 			// alloc objects
 			_poc = new PresenterObjectsContainer(

--- a/simpledisplay.d
+++ b/simpledisplay.d
@@ -1229,7 +1229,7 @@ version(Windows) {
 			DWM_WINDOW_CORNER_PREFERENCE value,
 			out CornerStyle result,
 		) @safe pure nothrow @nogc {
-			switch(value) with (DWM_WINDOW_CORNER_PREFERENCE) {
+			switch (value) with (DWM_WINDOW_CORNER_PREFERENCE) {
 				case DWMWCP_DEFAULT:
 					result = CornerStyle.automatic;
 					return true;
@@ -1237,8 +1237,10 @@ version(Windows) {
 					result = CornerStyle.rectangular;
 					return true;
 				case DWMWCP_ROUND:
-				case DWMWCP_ROUNDSMALL:
 					result = CornerStyle.rounded;
+					return true;
+				case DWMWCP_ROUNDSMALL:
+					result = CornerStyle.roundedSlightly;
 					return true;
 				default:
 					return false;
@@ -1249,7 +1251,7 @@ version(Windows) {
 			CornerStyle value,
 			out DWM_WINDOW_CORNER_PREFERENCE result,
 		) @safe pure nothrow @nogc {
-			final switch(value) with (DWM_WINDOW_CORNER_PREFERENCE) {
+			final switch (value) with (DWM_WINDOW_CORNER_PREFERENCE) {
 				case CornerStyle.automatic:
 					result = DWMWCP_DEFAULT;
 					return true;
@@ -1258,6 +1260,9 @@ version(Windows) {
 					return true;
 				case CornerStyle.rounded:
 					result = DWMWCP_ROUND;
+					return true;
+				case CornerStyle.roundedSlightly:
+					result = DWMWCP_ROUNDSMALL;
 					return true;
 			}
 		}
@@ -1908,6 +1913,11 @@ enum CornerStyle {
 		Prefer rounded window corners
 	 +/
 	rounded,
+
+	/++
+		Prefer slightly-rounded window corners
+	 +/
+	roundedSlightly,
 }
 
 /++


### PR DESCRIPTION
As discussed on Discord, here’s my PR to add this feature.
This reclaims the pixels otherwise lost to rounded window corners.

Tested on Windows 11 + Windows 10 (where it does nothing due to the lack of support for the underlying feature, but does not crash either).

For convenience reasons we currently provide a dummy for unsupported systems that stores the value in a field without further processing. (This is also used as a fallback on unsupported Windows versions.)

In my tests (cross-linking on Linux!) it also works without explicitly passing `dwmapi` to the linker.
Not sure about Windows and the MS linker though. I think we should keep it – even if it’s just for cleanness purposes.

In general, I’d appreciate if someone developing on Windows could give this a try; thanks!

<details>

<summary>Credit where credit is due…</summary>

- <https://github.com/mgba-emu/mgba/issues/3285>
- <https://dolphin-emu.org/blog/2024/09/04/dolphin-progress-report-release-2407-2409/#50-21462-windows-remove-rounded-corners-on-emulation-render-window-by-filoppi>

</details>