### PR TITLE
Timer conflict

### DIFF
--- a/core.d
+++ b/core.d
@@ -3708,6 +3708,9 @@ package(arsd) __gshared CleanupQueue cleanupQueue;
 		slow could lock up the event loop. It now guarantees other things will
 		get a chance to run between timer calls, even if that means not keeping up
 		with the requested interval.
+
+		Originally part of arsd.simpledisplay, this code was integrated into
+		arsd.core on May 26, 2024 (committed on June 10).
 +/
 version(HasTimer)
 class Timer {

--- a/pixmappresenter.d
+++ b/pixmappresenter.d
@@ -192,7 +192,12 @@ alias Pixmap = arsd.pixmappaint.Pixmap;
 alias WindowResizedCallback = void delegate(Size);
 
 // is the Timer class available on this platform?
-private enum hasTimer = is(Timer == class);
+private enum hasTimer = is(arsd.simpledisplay.Timer == class);
+
+// resolve symbol clash on “Timer” (arsd.core vs arsd.simpledisplay)
+static if (hasTimer) {
+	private alias Timer = arsd.simpledisplay.Timer;
+}
 
 // viewport math
 private @safe pure nothrow @nogc {


### PR DESCRIPTION
Recent changes introduced a symbol conflict that broke PixmapPresenter.