### PR TITLE
arsd.email: Don't needlessly link libcurl

### DIFF
--- a/email.d
+++ b/email.d
@@ -14,7 +14,6 @@
 module arsd.email;
 
 import std.net.curl;
-pragma(lib, "curl");
 
 import std.base64;
 import std.string;


### PR DESCRIPTION
`std.net.curl` loads the library and symbols dynamically at runtime.