### PR TITLE
fix(terminal): fix conditional binding for musl

### DIFF
--- a/terminal.d
+++ b/terminal.d
@@ -393,9 +393,11 @@ version(CRuntime_Musl) {
 	// We define our own bindings whenever the import fails.
 	// When druntime catches up, this block can slowly be removed,
 	// although for backward compatibility we might want to keep it.
-	static if (!__traits(compiles, import core.sys.posix.termios : tcgetattr)) {
-		int tcgetattr (int, struct termios *);
-		int tcsetattr (int, int, const struct termios *);
+	static if (!__traits(compiles, { import core.sys.posix.termios : tcgetattr; })) {
+		extern (C) {
+			int tcgetattr (int, termios *);
+			int tcsetattr (int, int, const termios *);
+		}
 	}
 }
 


### PR DESCRIPTION
I am an idiot. I got the compiles import syntax wrong and missed the extern C.

Now tested it with actual musl environment, so this should be fine.