### PR TITLE
Do not send empty chunk for HEAD requests

### DIFF
--- a/cgi.d
+++ b/cgi.d
@@ -2735,7 +2735,7 @@ class Cgi {
 		}
 
 		// closing the last chunk...
-		if(nph && rawDataOutput !is null && responseChunked)
+		if(requestMethod != RequestMethod.HEAD && nph && rawDataOutput !is null && responseChunked)
 			rawDataOutput(cast(const(ubyte)[]) "0\r\n\r\n");
 
 		if(flushDelegate)


### PR DESCRIPTION
`HEAD` requests are not supposed to have a body.

MDN suggests that…

> If a response to a HEAD request has a body, the response body must be ignored.

Web browser seem to handle such situations well.

Unfortunately, Node.js does not; instead it tries to parse the empty chunk as a new HTTP response and reports an error.
(Code `HPE_INVALID_CONSTANT` with reason "Expected HTTP/")