### PR TITLE
Adopt dependency injection (DI) library from oceandrift

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Future release, likely May 2026 or later.
 Pending changes:
     * arsd.jsvar's toJson function now includes `null` values by default. This is to make json use cases easier. You can get the old behavior back by setting the `var.includeExplicitNullsWhenConvertingToJson = false;` setting in your thread.
 	* arsd.gr, a math library for golden ratio constants and calculations, was added.
+	* arsd.di, the dependency injection (DI) framework originally developed as *oceandrift/di*, was added.
 
 Planned changes:
 

--- a/di.d
+++ b/di.d
@@ -212,13 +212,6 @@
 	---
 	auto di = new DI();
 	---
-
-	One can also supply a previously created dependency container:
-	---
-	auto container = new DIContainer();
-	// …
-	auto di = new DI(container);
-	---
  +/
 module oceandrift.di;
 

--- a/di.d
+++ b/di.d
@@ -786,18 +786,20 @@ final class DI {
 
 			static foreach (idx, P; ctorParams) {
 				static if (isStruct!P) {
-					pragma(
-						msg,
-						"DI Warning: Passing dependency #"
-							~ idx.to!string()
-							~ " `"
-							~ P.stringof
-							~ "` by value (copy) to `"
-							~ T.stringof
-							~ "`.\n            Use a pointer (`"
-							~ P.stringof
-							~ "*`) instead."
-					);
+					version (diNoPassByValue) {
+						static assert(
+							false,
+							"Passing dependency #"
+								~ idx.to!string()
+								~ " `"
+								~ P.stringof
+								~ "` by value (copy) to `"
+								~ T.stringof
+								~ "`.\n            Use a pointer (`"
+								~ P.stringof
+								~ "*`) instead. [`-version=diNoPassByValue`]"
+						);
+					}
 					mixin(`P* param` ~ idx.to!string() ~ ';');
 				} else {
 					mixin(`P param` ~ idx.to!string() ~ ';');
@@ -912,8 +914,7 @@ final class DI {
 	Bar* bar = di.resolve!Bar();
 	bar.i = 2;
 
-	pragma(msg, "The following DI Warning (\"Passing `Bar` by value\") is fine when running unittests:");
-	Foo foo = di.resolve!Foo(); // emits a DI Warning
+	Foo foo = di.resolve!Foo();
 	bar.i = 3;
 	assert(foo.bar.i == 2);
 }

--- a/di.d
+++ b/di.d
@@ -207,7 +207,11 @@
 	For pointers, deferencing them might also be an option.
 
 
+
+
 	Examples:
+
+	### Bootstrapping
 
 	Bootstrapping the framework is as simple as:
 
@@ -218,7 +222,7 @@
 module oceandrift.di;
 
 /++
-	Extended version of the front-page example
+	### Extended version of the front-page example
  +/
 @safe unittest {
 	static  // exclude from docs
@@ -247,7 +251,7 @@ module oceandrift.di;
 }
 
 /++
-	User-supplied dependency instances
+	### User-supplied dependency instances
 
 	$(BLOCKQUOTE
 		How about types the framework cannot construct on its own?
@@ -294,7 +298,7 @@ module oceandrift.di;
 }
 
 /++
-	Injecting dependencies that are $(I Interfaces)
+	### Injecting dependencies that are interfaces
 
 	It’s really straightforward:
 	Tell the framework which implementation type to use for dependencies of an interface type.
@@ -347,10 +351,10 @@ module oceandrift.di;
 }
 
 /++
-	Injecting dependencies that are $(I Interfaces) (Part II)
+	### Injecting dependencies that are interfaces (Part II)
 
-	// What if we had a type with a complex constructor,
-	// one that the framework cannot instantiate on its own?
+	What if we had a type with a complex constructor,
+	one that the framework cannot instantiate on its own?
  +/
 @system unittest {
 	static  // exclude from docs

--- a/di.d
+++ b/di.d
@@ -424,7 +424,7 @@ module oceandrift.di;
 		  and a body that assigns the values to the corresponding fields.
 	)
  +/
-@system unittest {
+@safe unittest {
 	static  // exclude from docs
 	class Dependency1 {
 	}

--- a/di.d
+++ b/di.d
@@ -409,6 +409,50 @@ module oceandrift.di;
 	assert(fileLogger.lines == 1); // alright!
 }
 
+/++
+	### DI-constructor generator
+
+	> All that typing gets tedious quickly, doesn’t it?
+
+	The framework can generate all the constructor boilerplate.
+	It’s as easy as:
+
+	$(NUMBERED_LIST
+		* Annotate all dependency fields with [dependency|@dependency].
+		* Add `mixin` [DIConstructor] to your type.
+		  This generates a constructor with a parameter for each `@dependency` field
+		  and a body that assigns the values to the corresponding fields.
+	)
+ +/
+@system unittest {
+	static  // exclude from docs
+	class Dependency1 {
+	}
+
+	static  // exclude from docs
+	class Dependency2 {
+	}
+
+	static  // exclude from docs
+	class Foo {
+		// Mark dependencies with the attribute `@dependency`:
+		private @dependency {
+			Dependency1 d1;
+			Dependency2 d2;
+		}
+
+		// Let the framework generate the constructor:
+		mixin DIConstructor;
+	}
+
+	auto di = new DI();
+	Foo foo = di.resolve!Foo();
+
+	// It works:
+	assert(foo.d1 !is null);
+	assert(foo.d2 !is null);
+}
+
 import std.conv : to;
 import std.traits : Parameters;
 

--- a/di.d
+++ b/di.d
@@ -16,7 +16,7 @@
 	)
 
 
-	## About Dependency Injection
+	### About Dependency Injection
 
 	$(SIDEBAR
 		Dependency Injection is commonly abbreviated as $(B DI).
@@ -32,7 +32,7 @@
 	They can be stored in one big repository, the [DIContainer|dependency container],
 	and retrieved later as needed.
 
-	### Declaration of dependencies
+	#### Declaration of dependencies
 
 	One of the most useful ways to specify the dependencies of a type (as in `class` or `struct`)
 	is to declare a constructor with them as parameters.
@@ -50,7 +50,7 @@
 	}
 	---
 
-	### Retrieval of dependencies
+	#### Retrieval of dependencies
 
 	Getting the dependencies from the container into the service object is where the DI framework comes in.
 	While the user could manually retrieve them from the container and pass them to the constructor
@@ -65,12 +65,12 @@
 	LoginService service = di.resolve!LoginService();
 	---
 
-	### Registration of dependencies
+	#### Registration of dependencies
 
 	But where did the `PasswordHashUtil`, the `Logger` and the `DatabaseClient` come from?
 	How did they get into the DI container?
 
-	#### Standalone dependencies
+	##### Standalone dependencies
 
 	Let’s assume the `PasswordHashUtil` has zero dependencies itself – it is a self-contained service class.
 	Its constructor has either no parameters
@@ -86,12 +86,12 @@
 	}
 	---
 
-	##### Custom dependency registrations
+	###### Custom dependency registrations
 
 	In case a user-provided `PasswordHashUtil` instance has been registered in advance,
 	the framework will skip the construction and use that one instead.
 
-	#### Transitive dependencies
+	##### Transitive dependencies
 
 	Aka “dependencies of a dependency”.
 
@@ -116,7 +116,7 @@
 	}
 	---
 
-	##### Custom dependency registrations
+	###### Custom dependency registrations
 
 	In case a user-provided `Logger` instance has been registered in advance,
 	the framework will skip all construction steps and use that one instead.
@@ -134,7 +134,7 @@
 		with the framework in addition to their custom `Logger` one.
 	)
 
-	#### Complex dependencies
+	##### Complex dependencies
 
 	Unlike the dependencies shown in the previous two chapters, however,
 	the `DatabaseClient` doesn’t depend on a bunch of other services.
@@ -169,12 +169,12 @@
 	---
 
 
-	## Unconventional use
+	### Unconventional use
 
 	This chapter deals with solutions to overcome the conventions of the framework.
 	(Malicious gossip has it that these are “design limitations”. Don’t listen to them…)
 
-	### Injecting non-singleton instances
+	#### Injecting non-singleton instances
 
 	Non-singleton objects are sometimes also called “transient” or “prototype”.
 
@@ -197,13 +197,28 @@
 
 	Alternatively, one could also create a factory type and use that as a dependency instead.
 
-	### Injecting dependencies that are primitive/unsupported types
+	#### Injecting dependencies that are primitive/unsupported types
 
 	The recommended way to inject primitives types (like integers, booleans, floating-point numbers, or enums)
 	or other unsupported types (e.g. strings, other arrays, associative arrays, class pointers or pointers in general)
 	is to wrap them in a struct.
 
 	For pointers, deferencing them might also be an option.
+
+
+	Examples:
+
+	Bootstrapping the framework is as simple as:
+	---
+	auto di = new DI();
+	---
+
+	One can also supply a previously created dependency container:
+	---
+	auto container = new DIContainer();
+	// …
+	auto di = new DI(container);
+	---
  +/
 module oceandrift.di;
 
@@ -489,6 +504,8 @@ public alias DIContainer = Container;
 
 /++
 	Dependency Injection
+
+	This is the flagship class of the framework.
  +/
 final class DI {
 	private {
@@ -600,8 +617,12 @@ final class DI {
 					} else static if (isStruct!P) {
 						pragma(
 							msg,
-							"DI Warning: Passing struct instance by value to constructor parameter " ~ idx.to!string() ~ " (`"
-								~ P.stringof ~ "`) of type `" ~ T.stringof ~ "`."
+							"DI Warning: Passing struct instance by value to constructor parameter "
+								~ idx.to!string()
+								~ " (`"
+								~ P.stringof ~ "`) of type `"
+								~ T.stringof
+								~ "`."
 						);
 						mixin(`P param` ~ idx.to!string() ~ ';');
 						mixin(`param` ~ idx.to!string()) = *this.resolve!P();
@@ -623,6 +644,8 @@ final class DI {
 		}
 	}
 }
+
+// Container Tests
 
 @safe unittest {
 	static struct Foo {
@@ -667,6 +690,8 @@ final class DI {
 	c.set!Bar(null);
 	assert(c.has!Bar() == false);
 }
+
+// DI Tests
 
 @safe unittest {
 	static class Bar {

--- a/di.d
+++ b/di.d
@@ -217,9 +217,6 @@
  +/
 module oceandrift.di;
 
-import std.conv : to;
-import std.traits : Parameters;
-
 /++
 	Extended version of the front-page example
  +/
@@ -407,6 +404,9 @@ import std.traits : Parameters;
 	service2.doSomething();
 	assert(fileLogger.lines == 1); // alright!
 }
+
+import std.conv : to;
+import std.traits : Parameters;
 
 private enum bool isClass(T) = (is(T == class));
 private enum bool isInterface(T) = (is(T == interface));

--- a/di.d
+++ b/di.d
@@ -261,3 +261,72 @@ final class DI {
 		}
 	}
 }
+
+unittest {
+	static struct Foo {
+		int i = 10;
+	}
+
+	static class Bar {
+		int i = 10;
+	}
+
+	auto c = new Container();
+	assert(c.has!Foo() == false);
+	assert(c.has!Bar() == false);
+	assert(c.get!Foo() is null);
+	assert(c.get!Bar() is null);
+
+	auto origFoo = new Foo();
+	origFoo.i = 2;
+	auto origBar = new Bar();
+	origBar.i = 3;
+
+	c.set(origFoo);
+	c.set(origBar);
+	assert(c.has!Foo());
+	assert(c.has!Bar());
+	assert(c.get!Foo() !is null);
+	assert(c.get!Bar() !is null);
+
+	auto cFoo = c.get!Foo();
+	auto cBar = c.get!Bar();
+	assert(cFoo.i == 2);
+	assert(cBar.i == 3);
+	assert(cFoo is origFoo);
+	assert(cBar is origBar);
+
+	cFoo.i = 4;
+	assert(origFoo.i == 4);
+
+	c.set!Foo(null);
+	assert(c.has!Foo() == false);
+
+	c.set!Bar(null);
+	assert(c.has!Bar() == false);
+}
+
+unittest {
+	static class Bar {
+		int i = 10;
+	}
+
+	static class Foo {
+		Bar bar;
+
+		this(Bar bar) {
+			this.bar = bar;
+		}
+	}
+
+	auto di = new DI();
+	Foo foo = di.resolve!Foo();
+	assert(foo !is null);
+	assert(foo.bar !is null);
+
+	// Test singleton behavior
+	assert(foo.bar.i == 10);
+	Bar bar = di.resolve!Bar();
+	bar.i = 2;
+	assert(foo.bar.i == 2);
+}

--- a/di.d
+++ b/di.d
@@ -21,7 +21,7 @@ private {
 		private static immutable string keyOf = T.mangleof;
 	}
 
-	template keyOf(T) if (is(T == struct)) {
+	template keyOf(T) if (isStruct!T) {
 		private static immutable string keyOf = (T*).mangleof;
 	}
 
@@ -78,7 +78,7 @@ final class Container {
 	/++
 		Returns a stored value by struct
 	 +/
-	T* get(T)() @nogc if (is(T == struct)) {
+	T* get(T)() @nogc if (isStruct!T) {
 		return getTImpl!(T*);
 	}
 
@@ -115,7 +115,7 @@ final class Container {
 	/++
 		Stores the provided pointer to a struct instance
 	 +/
-	void set(T)(T* value) if (is(T == struct)) {
+	void set(T)(T* value) if (isStruct!T) {
 		this.setTImpl!(T*)(value);
 	}
 
@@ -152,7 +152,7 @@ final class DI {
 	 +/
 	auto resolve(T)() if (false) {
 		static assert(
-			isClass!T || is(T == struct),
+			isClass!T || isStruct!T,
 			"Cannot resolve instance of type `" ~ T.stringof ~ "`. Not a class or struct."
 		);
 
@@ -180,7 +180,7 @@ final class DI {
 
 	/++
 	 +/
-	T* resolve(T)() if (is(T == struct)) {
+	T* resolve(T)() if (isStruct!T) {
 		void** ptrptr = _container.getPtr(keyOf!T);
 		if (ptrptr !is null) {
 			return ((void* ptr) @trusted => cast(T*) ptr)(*ptrptr);
@@ -214,7 +214,7 @@ final class DI {
 		_container.set(value);
 	}
 
-	private T* makeNew(T)() if (is(T == struct)) {
+	private T* makeNew(T)() if (isStruct!T) {
 		return new T();
 	}
 
@@ -236,7 +236,7 @@ final class DI {
 				static if (isClass!P || isStructPointer!P) {
 					mixin(`P param` ~ idx.to!string() ~ ';');
 					mixin(`param` ~ idx.to!string()) = this.resolve!P();
-				} else static if (is(P == struct)) {
+				} else static if (isStruct!P) {
 					pragma(
 						msg,
 						"DI Warning: Passing struct instance by value to parameter `"

--- a/di.d
+++ b/di.d
@@ -191,7 +191,7 @@
 		public this(
 			DI di,
 		) {
-			this.dependency = DI.makeNew!Dependency();
+			this.dependency = di.makeNew!Dependency();
 		}
 		---
 	)

--- a/di.d
+++ b/di.d
@@ -1,0 +1,263 @@
+/++
+	Lightweight Dependency Injection (DI) framework
+ +/
+module oceandrift.di;
+
+import std.conv : to;
+import std.traits : Parameters;
+
+private enum bool isClass(T) = (is(T == class));
+private enum bool isStruct(T) = (is(T == struct));
+private enum bool isStructPointer(T) = (is(typeof(*T) == struct));
+
+private enum bool hasConstructors(T) = __traits(hasMember, T, "__ctor");
+
+private template getConstructors(T) if (hasConstructors!T) {
+	alias getConstructors = __traits(getOverloads, T, "__ctor");
+}
+
+private {
+	template keyOf(T) if (isClass!T) {
+		private static immutable string keyOf = T.mangleof;
+	}
+
+	template keyOf(T) if (is(T == struct)) {
+		private static immutable string keyOf = (T*).mangleof;
+	}
+
+	template keyOf(T) if (isStructPointer!T) {
+		private static immutable string keyOf = T.mangleof;
+	}
+}
+
+/++
+	Container for singleton instances
+ +/
+final class Container {
+@safe pure nothrow:
+
+	private {
+		alias voidptr = void*;
+		voidptr[string] _data;
+	}
+
+	///
+	public this() {
+		this.setSelf();
+	}
+
+	// CAUTION: This function cannot be exposed publicly for @safe-ty guarantees
+	private void** getPtr(string key) @nogc {
+		return (key in _data);
+	}
+
+	/++
+		Returns a stored value by key
+	 +/
+	void* get(string key) @nogc {
+		void** ptrptr = (key in _data);
+		if (ptrptr is null) {
+			return null;
+		}
+
+		return *ptrptr;
+	}
+
+	private T getTImpl(T)() @nogc {
+		void* ptr = this.get(keyOf!T);
+		return (function(void* ptr) @trusted => cast(T) ptr)(ptr);
+	}
+
+	/++
+		Returns a stored value by class
+	 +/
+	T get(T)() @nogc if (isClass!T) {
+		return getTImpl!T();
+	}
+
+	/++
+		Returns a stored value by struct
+	 +/
+	T* get(T)() @nogc if (is(T == struct)) {
+		return getTImpl!(T*);
+	}
+
+	/++
+		Determines whether a value matching the provided key is stored
+	 +/
+	bool has(string key) @nogc {
+		return (this.get(key) !is null);
+	}
+
+	/// ditto
+	bool has(T)() @nogc {
+		return this.has(keyOf!T);
+	}
+
+	// CAUTION: This function cannot be exposed publicly for @safe-ty guarantees
+	private void set(string key, void* value) {
+		_data[key] = value;
+	}
+
+	private void setTImpl(T)(T value) {
+		pragma(inline, true);
+		void* ptr = (function(T value) @trusted => cast(void*) value)(value);
+		this.set(keyOf!T, ptr);
+	}
+
+	/++
+		Stores the provided class instance
+	 +/
+	void set(T)(T value) if (isClass!T && !is(T == Container) && !is(T == DI)) {
+		this.setTImpl!T(value);
+	}
+
+	/++
+		Stores the provided pointer to a struct instance
+	 +/
+	void set(T)(T* value) if (is(T == struct)) {
+		this.setTImpl!(T*)(value);
+	}
+
+	private void setSelf() {
+		this.setTImpl!Container(this);
+	}
+
+	private void setDI(DI value) {
+		this.setTImpl!DI(value);
+	}
+}
+
+/++
+	Dependency Injection
+ +/
+final class DI {
+	private {
+		Container _container;
+	}
+
+	///
+	this(Container container) @safe pure nothrow {
+		// main ctor
+		_container = container;
+		_container.setDI = this;
+	}
+
+	///
+	this() @safe pure nothrow {
+		this(new Container());
+	}
+
+	/++
+	 +/
+	auto resolve(T)() if (false) {
+		static assert(
+			isClass!T || is(T == struct),
+			"Cannot resolve instance of type `" ~ T.stringof ~ "`. Not a class or struct."
+		);
+
+		void** ptrptr = _container.getPtr(keyOf!T);
+		if (ptrptr !is null) {
+			return ((void* ptr) @trusted => cast(T)*ptr)(*ptrptr);
+		}
+
+		return _container.get!T();
+	}
+
+	/++
+	 +/
+	T resolve(T)() if (isClass!T) {
+		void** ptrptr = _container.getPtr(keyOf!T);
+		if (ptrptr !is null) {
+			return (function(void* ptr) @trusted => cast(T) ptr)(*ptrptr);
+		}
+
+		T instance = this.makeNew!T();
+		this.store!T = instance;
+
+		return instance;
+	}
+
+	/++
+	 +/
+	T* resolve(T)() if (is(T == struct)) {
+		void** ptrptr = _container.getPtr(keyOf!T);
+		if (ptrptr !is null) {
+			return ((void* ptr) @trusted => cast(T*) ptr)(*ptrptr);
+		}
+
+		T* instance = this.makeNew!T();
+		this.store!(T*) = instance;
+
+		return _container.get!T();
+	}
+
+	/++
+		Stores the provided instance of type `T` in the DI container.
+
+		Overrides the previously stored instance if applicable.
+	 +/
+	void store(T)(T value) @safe pure nothrow {
+		static assert(
+			isClass!T || isStructPointer!T,
+			"Cannot store instance of type `" ~ T.stringof ~ "`. Not a class or struct-pointer."
+		);
+		static assert(
+			!is(T == Container),
+			"Cannot override the referenced Container instance."
+		);
+		static assert(
+			!is(T == DI),
+			"Cannot override the referenced DI instance."
+		);
+
+		_container.set(value);
+	}
+
+	private T* makeNew(T)() if (is(T == struct)) {
+		return new T();
+	}
+
+	/++ 
+	 +/
+	T makeNew(T)() if (isClass!T) {
+		static if (!hasConstructors!(T)) {
+			return new T();
+		} else {
+			alias ctors = getConstructors!T;
+			static assert(
+				ctors.length <= 1,
+				"DI cannot instantiate object of class `" ~ T.stringof ~ "` which has multiple constructors."
+			);
+
+			alias params = Parameters!(ctors[0]);
+
+			static foreach (idx, P; params) {
+				static if (isClass!P || isStructPointer!P) {
+					mixin(`P param` ~ idx.to!string() ~ ';');
+					mixin(`param` ~ idx.to!string()) = this.resolve!P();
+				} else static if (is(P == struct)) {
+					pragma(
+						msg,
+						"DI Warning: Passing struct instance by value to parameter `"
+							~ P.stringof ~ "` of type `" ~ T.stringof ~ "`."
+					);
+					mixin(`P param` ~ idx.to!string() ~ ';');
+					mixin(`param` ~ idx.to!string()) = *this.resolve!P();
+				} else {
+					static assert(false, "Cannot resolve a value for constructor parameter " ~ idx ~ "");
+				}
+			}
+
+			enum paramList = (function() {
+					string r = "";
+					foreach (idx, p; params) {
+						r ~= "param" ~ idx.to!string() ~ ',';
+					}
+					return r;
+				})();
+
+			return mixin(`new T(` ~ paramList ~ `)`);
+		}
+	}
+}

--- a/di.d
+++ b/di.d
@@ -1,3 +1,8 @@
+/+
+	== oceandrift/di ==
+	Copyright Elias Batek 2024.
+	Distributed under the Boost Software License, Version 1.0.
+ +/
 /++
 	Lightweight Dependency Injection (DI) framework
  +/

--- a/di.d
+++ b/di.d
@@ -465,6 +465,16 @@ private {
 public enum bool isSupportedDependencyType(T) = (isClass!T || isInterface!T || isStruct!T || isStructPointer!T);
 
 /++
+	Determines whether a type `T` is denied for user registration.
+ +/
+public enum bool isForbiddenType(T) = is(T == Container) || is(T == DI);
+
+/++
+	Determines whether a type `T` is applicable for user registration.
+ +/
+public enum bool isntForbiddenType(T) = !(isForbiddenType!T);
+
+/++
 	Determines $(I why) a type `T` is not constructable by the DI framework.
 
 	Returns:
@@ -629,7 +639,7 @@ private final class Container {
 	/++
 		Stores the provided class instance
 	 +/
-	void set(T)(T value) if ((isClass!T && !is(T == Container) && !is(T == DI)) || isInterface!T) {
+	void set(T)(T value) if ((isClass!T || isInterface!T) && (isntForbiddenType!T)) {
 		this.setTImpl!T(value);
 	}
 
@@ -726,12 +736,8 @@ final class DI {
 			"Cannot store instance of type `" ~ T.stringof ~ "`. Not a class, interface or struct-pointer."
 		);
 		static assert(
-			!is(T == Container),
-			"Cannot override the referenced Container instance."
-		);
-		static assert(
-			!is(T == DI),
-			"Cannot override the referenced DI instance."
+			isntForbiddenType!T,
+			"Cannot override the referenced framework instance of type `" ~ T.stringof ~ "`."
 		);
 
 		_container.set(value);

--- a/di.d
+++ b/di.d
@@ -1,5 +1,5 @@
 /+
-	== arsd.di (originally known as *oceandrift/di*)==
+	== arsd.di (originally known as *oceandrift/di*) ==
 	Copyright Elias Batek 2024.
 	Distributed under the Boost Software License, Version 1.0.
  +/

--- a/di.d
+++ b/di.d
@@ -1,5 +1,5 @@
 /+
-	== oceandrift/di ==
+	== arsd.di (originally known as *oceandrift/di*)==
 	Copyright Elias Batek 2024.
 	Distributed under the Boost Software License, Version 1.0.
  +/
@@ -143,7 +143,7 @@
 	While the injection of a `DatabaseClient` into dependent services principally works like before,
 	the framework cannot instantiate a new one by itself.
 	Hence it is that an instance has to be registered with the framework in advance.
-	A user-created `DatabaseClient` can provided by passing it to [oceandrift.di.DI.register|register()].
+	A user-created `DatabaseClient` can provided by passing it to [arsd.di.DI.register|register()].
 
 	The framework will pick up on it later, when it constructs `LoginService`
 	or, failing that, if no custom instance has been registered beforehand,
@@ -182,7 +182,7 @@
 	and use it for all dependent objects.
 
 	When this behavior is not desired, it’s recommended to instantiate a new object in the constructor.
-	Check out [oceandrift.di.DI.makeNew|makeNew!(T)].
+	Check out [arsd.di.DI.makeNew|makeNew!(T)].
 
 	$(TIP
 		The DI framework can inject a reference to itself.
@@ -219,7 +219,7 @@
 	auto di = new DI();
 	---
  +/
-module oceandrift.di;
+module arsd.di;
 
 /++
 	### Extended version of the front-page example
@@ -963,7 +963,7 @@ enum _diConstructorUDA;
 	and assigns the passed value to the corresponding field.
  +/
 mixin template DIConstructor() {
-	import oceandrift.di : dependency, diConstructorString, _diConstructorUDA;
+	import arsd.di : dependency, diConstructorString, _diConstructorUDA;
 
 	mixin(diConstructorString!(typeof(this)));
 }

--- a/dub.json
+++ b/dub.json
@@ -838,6 +838,14 @@
 					"versions": ["ArsdGrCalculatorMain"]
 				}
 			]
+		},
+		{
+			"name": "di",
+			"description": "Lightweight Dependency Injection (DI) framework.",
+			"sourceFiles": ["di.d"],
+			"dflags-dmd": ["-mv=arsd.di=$PACKAGE_DIR/di.d"],
+			"dflags-ldc": ["--mv=arsd.di=$PACKAGE_DIR/di.d"],
+			"dflags-gdc": ["-fmodule-file=arsd.di=$PACKAGE_DIR/di.d"]
 		}
 	]
 }


### PR DESCRIPTION
This adds `arsd.di` based on the dependency injection framework previously known as [*oceandrift/di*](https://github.com/oceandrift/di).